### PR TITLE
Dockerizando o bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --update \
     # necessário para ter o 'getopt' mais atual
     util-linux
 
-# melhor maneira encontrada para pegar versão atual no 'jq' no alpine
+# melhor maneira encontrada para pegar versão atual do 'jq' no alpine
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x jq-linux64 && \
     mv jq-linux64 /usr/bin/jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine
+
+ADD . /home/bot
+
+RUN apk add --update \
+    bash \
+    curl \
+    # necessário para ter o 'getopt' mais atual
+    util-linux
+
+# melhor maneira encontrada para pegar versão atual no 'jq' no alpine
+RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+    chmod +x jq-linux64 && \
+    mv jq-linux64 /usr/bin/jq
+
+ARG token
+ENV TOKEN "${token}"
+
+CMD /bin/bash /home/bot/exemplos/BotTerminal.sh ${TOKEN}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ Exemplo:
 $ cp ShellBot.sh /projeto/meu_bot/
 ```
 
+## Docker
+
+Para testar diretamente usando um container docker. Tenha em mãos o token do seu bot.
+
+```
+$ git clone https://github.com/shellscriptx/ShellBot.git && cd ShellBot
+```
+
+```
+$ docker build -t shellbot --build-arg "token=<TOKEN>" .
+```
+
+```
+$ docker run -it shellbot
+```
+
 ## Documentação
 
 Para mais informações consulte a documentação do projeto na página [wiki](https://github.com/shellscriptx/ShellBot/wiki).

--- a/exemplos/BotTerminal.sh
+++ b/exemplos/BotTerminal.sh
@@ -5,11 +5,14 @@
 # Para melhor compreensão foram utilizados parâmetros longos nas funções; Podendo
 # ser substituidos pelos parâmetros curtos respectivos.
 
+# Variável contem diretório onde o script reside
+BASEDIR=$(dirname $0)
+
 # Importando API
-source ShellBot.sh
+source ${BASEDIR}/../ShellBot.sh
 
 # Token do bot
-bot_token='<TOKEN_AQUI>'
+bot_token=$1
 
 # Inicializando o bot com log.
 ShellBot.init --token "$bot_token" --monitor --flush --log_file "/tmp/${0##*/}.log"


### PR DESCRIPTION
A ideia é facilitar um pouco mais para que o usuário possa testar os scripts (exemplos) da API.
Com 2 comandos docker, o usuário irá ter um bot rodando pronto para testes.

Dependências: Docker & Telegram TOKEN
ps. Se usar essa abordagem, o usuário não precisa das outras dependências (jq, curl...)